### PR TITLE
Add support for sending logs via TCP over SSL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Logback appender that sends GELF messages
 
-Send log events to a Graylog2 server by GELF protocol over UDP, TCP or AMQP
-transport.
+Send log events to a Graylog2 server by GELF protocol over UDP, TCP, TCP over SSL or
+AMQP transport.
 
 
 == Usage
@@ -57,6 +57,7 @@ To send by AMQP:
     Host name of Graylog2 server where it will send the GELF messages.
     Prefix with `udp:` to send by UDP.
     Prefix with `tcp:` to send by TCP.
+    Prefix with `ssl:` to send by TCP over SSL.
     If neither prefix is present, then the transport is UDP.
 
 `graylogPort`::
@@ -98,3 +99,6 @@ To send by AMQP:
 
 `amqpMaxRetries`::
     Maximum retries count; default value 0 (*optional*)
+
+`sslTrustAllCertificates`::
+    Skip SSL Server Certificate Validation; default false (*optional*)

--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import com.github.pukkaone.gelf.protocol.GelfAMQPSender;
 import com.github.pukkaone.gelf.protocol.GelfMessage;
+import com.github.pukkaone.gelf.protocol.GelfSSLSender;
 import com.github.pukkaone.gelf.protocol.GelfSender;
 import com.github.pukkaone.gelf.protocol.GelfTCPSender;
 import com.github.pukkaone.gelf.protocol.GelfUDPSender;
@@ -36,6 +37,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private String amqpExchange;
     private String amqpRoutingKey;
     private int amqpMaxRetries;
+    private boolean sslTrustAllCertificates = false;
     private GelfMessageFactory marshaller = new GelfMessageFactory();
     private GelfSender gelfSender;
 
@@ -172,6 +174,14 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         this.amqpMaxRetries = amqpMaxRetries;
     }
 
+    public boolean isSslTrustAllCertificates() {
+        return sslTrustAllCertificates;
+    }
+
+    public void setSslTrustAllCertificates(boolean sslTrustAllCertificates) {
+        this.sslTrustAllCertificates = sslTrustAllCertificates;
+    }
+
     private GelfUDPSender getGelfUDPSender(String graylogHost, int graylogPort)
         throws IOException
     {
@@ -182,6 +192,12 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         throws IOException
     {
         return new GelfTCPSender(graylogHost, graylogPort);
+    }
+
+    private GelfSSLSender getGelfSSLSender(String graylogHost, int graylogPort, boolean sslTrustAllCertificates)
+            throws IOException
+    {
+        return new GelfSSLSender(graylogHost, graylogPort, sslTrustAllCertificates);
     }
 
     private GelfAMQPSender getGelfAMQPSender(
@@ -206,7 +222,10 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         }
 
         try {
-            if (graylogHost != null && graylogHost.startsWith("tcp:")) {
+            if (graylogHost != null && graylogHost.startsWith("ssl:")) {
+                String sslGraylogHost = graylogHost.substring(4);
+                gelfSender = getGelfSSLSender(sslGraylogHost, graylogPort, sslTrustAllCertificates);
+            } else if (graylogHost != null && graylogHost.startsWith("tcp:")) {
                 String tcpGraylogHost = graylogHost.substring(4);
                 gelfSender = getGelfTCPSender(tcpGraylogHost, graylogPort);
             } else if (graylogHost != null && graylogHost.startsWith("udp:")) {

--- a/src/main/java/com/github/pukkaone/gelf/protocol/GelfSSLSender.java
+++ b/src/main/java/com/github/pukkaone/gelf/protocol/GelfSSLSender.java
@@ -1,0 +1,63 @@
+package com.github.pukkaone.gelf.protocol;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+
+public class GelfSSLSender extends GelfTCPSender {
+
+    private final SSLSocketFactory socketFactory;
+
+    public GelfSSLSender(String host, int port, boolean trustAllCertificates) throws IOException {
+        super(host, port);
+        try {
+            this.socketFactory = initSocketFactory(trustAllCertificates);
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new IOException("Could not find an SSL provider. Sending GELF logs won't work.", e);
+        }
+    }
+
+    private SSLSocketFactory initSocketFactory(boolean trustAllCertificates)
+            throws KeyManagementException, NoSuchAlgorithmException {
+
+        if (trustAllCertificates) {
+            SSLContext context = SSLContext.getInstance("SSL");
+            context.init(null, getAllTrustingTrustManagers(), new java.security.SecureRandom());
+            return context.getSocketFactory();
+        } else {
+            return (SSLSocketFactory) SSLSocketFactory.getDefault();
+        }
+    }
+
+    private TrustManager[] getAllTrustingTrustManagers() {
+        return new TrustManager[]{
+                new X509TrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                    }
+
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
+                }
+        };
+    }
+
+    @Override
+    protected Socket getSocket() throws IOException {
+        Socket tcpSocket = super.getSocket();
+        return socketFactory.createSocket(
+                tcpSocket,
+                tcpSocket.getInetAddress().getHostAddress(),
+                tcpSocket.getPort(),
+                true);
+    }
+}

--- a/src/main/java/com/github/pukkaone/gelf/protocol/GelfTCPSender.java
+++ b/src/main/java/com/github/pukkaone/gelf/protocol/GelfTCPSender.java
@@ -16,16 +16,19 @@ public class GelfTCPSender extends GelfSender {
 
     private OutputStreamWriter getWriter() throws IOException {
         if (socket == null) {
-            socket = new Socket(host, port);
+            socket = getSocket();
             writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
         }
         return writer;
     }
 
+    protected Socket getSocket() throws IOException {
+        return new Socket(host, port);
+    }
+
     public GelfTCPSender(String host, int port) throws IOException {
         this.host = InetAddress.getByName(host);
         this.port = port;
-        getWriter();
     }
 
     public boolean sendMessage(GelfMessage message) {


### PR DESCRIPTION
Add a sender for TCP over SSL which leverages the existing TCP sender by upgrading its socket. Tested working with an AWS Elastic Load Balancer (set up to terminate the SSL connection and forward internally via TCP) in front of an instance running logstash.
