### PR TITLE
Added a possibility to fill message timestamp from a custom MDC property

### DIFF
--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
@@ -40,6 +40,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private boolean sslTrustAllCertificates;
     private GelfMessageFactory marshaller = new GelfMessageFactory();
     private GelfSender gelfSender;
+    private String mdcTimestampProperty;
 
     public String getGraylogHost() {
         return graylogHost;
@@ -209,6 +210,14 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         throws IOException, URISyntaxException, NoSuchAlgorithmException, KeyManagementException
     {
         return new GelfAMQPSender(amqpURI, amqpExchange, amqpRoutingKey, amqpMaxRetries);
+    }
+
+    public String getMdcTimestampProperty() {
+        return mdcTimestampProperty;
+    }
+
+    public void setMdcTimestampProperty(String mdcTimestampProperty) {
+        this.mdcTimestampProperty = mdcTimestampProperty;
     }
 
     @Override

--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfMessageFactory.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfMessageFactory.java
@@ -61,6 +61,11 @@ public class GelfMessageFactory {
             Map<String, String> mdc = event.getMDCPropertyMap();
             if (mdc != null) {
                 for (Map.Entry<String, String> entry : mdc.entrySet()) {
+                    if (entry.getKey().equals(appender.getMdcTimestampProperty())) {
+                        message.setTimestampMillis(Long.parseLong(entry.getValue()));
+                        continue;
+                    }
+
                     message.addField(entry.getKey(), entry.getValue());
                 }
             }


### PR DESCRIPTION
GelfMessageFactory is looking for MDC key equal to GelfAppender.mdcTimestampProperty and if one is found, then current timestamp is replaced.

I need this so I can track messages as I received them, ane not by the time I've sent them to the graylog server.
