### PR TITLE
Added custom message factory support

### DIFF
--- a/src/main/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactory.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactory.java
@@ -1,0 +1,94 @@
+package com.github.pukkaone.gelf.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.util.LevelToSyslogSeverity;
+import com.github.pukkaone.gelf.protocol.GelfMessage;
+import org.slf4j.Marker;
+
+import java.util.Map;
+
+public class DefaultGelfMessageFactory implements GelfMessageFactory{
+
+    private PatternLayout shortPatternLayout;
+    private PatternLayout fullPatternLayout;
+
+    public DefaultGelfMessageFactory() {
+        // Short message contains event message and no stack trace.
+        shortPatternLayout = new PatternLayout();
+        shortPatternLayout.setContext(new LoggerContext());
+        shortPatternLayout.setPattern("%m%nopex");
+        shortPatternLayout.start();
+
+        // Full message contains stack trace.
+        fullPatternLayout = new PatternLayout();
+        fullPatternLayout.setContext(new LoggerContext());
+        fullPatternLayout.setPattern("%xEx");
+        fullPatternLayout.start();
+    }
+
+    public GelfMessage createMessage(GelfAppender appender, ILoggingEvent event) {
+        GelfMessage message = new GelfMessage()
+                .setTimestampMillis(event.getTimeStamp());
+
+        String originHost = appender.getOriginHost();
+        if (originHost != null) {
+            message.setHost(originHost);
+        }
+
+        if (appender.isLevelIncluded()) {
+            message.setLevel(LevelToSyslogSeverity.convert(event));
+        }
+
+        if (appender.isLocationIncluded()) {
+            StackTraceElement locationInformation = event.getCallerData()[0];
+            message.setFile(locationInformation.getFileName());
+            message.setLine(locationInformation.getLineNumber());
+        }
+
+        if (appender.isLoggerIncluded()) {
+            message.setLogger(event.getLoggerName());
+        }
+
+        if (appender.isMarkerIncluded()) {
+            Marker marker = event.getMarker();
+            if (marker != null) {
+                message.setMarker(marker.getName());
+            }
+        }
+
+        if (appender.isMdcIncluded()) {
+            Map<String, String> mdc = event.getMDCPropertyMap();
+            if (mdc != null) {
+                for (Map.Entry<String, String> entry : mdc.entrySet()) {
+                    addMessageField(mdc, message, entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        if (appender.isThreadIncluded()) {
+            message.setThread(event.getThreadName());
+        }
+
+        message.setShortMessage(shortPatternLayout.doLayout(event));
+
+        String fullMessage = fullPatternLayout.doLayout(event);
+        if (!fullMessage.isEmpty()) {
+            message.setFullMessage(fullMessage);
+        }
+
+        message.setFacility(appender.getFacility());
+
+        Map<String, String> fields = appender.getAdditionalFields();
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            addMessageField(fields, message, entry.getKey(), entry.getValue());
+        }
+
+        return message;
+    }
+
+    protected void addMessageField(Map<String, String> map, GelfMessage message, String key, Object value) {
+        message.addField(key, value);
+    }
+}

--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
@@ -39,7 +39,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private String amqpRoutingKey;
     private int amqpMaxRetries;
     private boolean sslTrustAllCertificates;
-    private GelfMessageFactory marshaller = new GelfMessageFactory();
+    private GelfMessageFactory marshaller = new DefaultGelfMessageFactory();
     private GelfSender gelfSender;
 
     public String getGraylogHost() {
@@ -189,6 +189,14 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
 
     public void setSslTrustAllCertificates(boolean sslTrustAllCertificates) {
         this.sslTrustAllCertificates = sslTrustAllCertificates;
+    }
+
+    public GelfMessageFactory getMarshaller() {
+        return marshaller;
+    }
+
+    public void setMarshaller(GelfMessageFactory marshaller) {
+        this.marshaller = marshaller;
     }
 
     private GelfUDPSender getGelfUDPSender(String graylogHost, int graylogPort)

--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfMessageFactory.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfMessageFactory.java
@@ -1,89 +1,9 @@
 package com.github.pukkaone.gelf.logback;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.util.LevelToSyslogSeverity;
 import com.github.pukkaone.gelf.protocol.GelfMessage;
-import java.util.Map;
-import org.slf4j.Marker;
 
-public class GelfMessageFactory {
+public interface GelfMessageFactory {
 
-    private PatternLayout shortPatternLayout;
-    private PatternLayout fullPatternLayout;
-
-    public GelfMessageFactory() {
-        // Short message contains event message and no stack trace.
-        shortPatternLayout = new PatternLayout();
-        shortPatternLayout.setContext(new LoggerContext());
-        shortPatternLayout.setPattern("%m%nopex");
-        shortPatternLayout.start();
-
-        // Full message contains stack trace.
-        fullPatternLayout = new PatternLayout();
-        fullPatternLayout.setContext(new LoggerContext());
-        fullPatternLayout.setPattern("%xEx");
-        fullPatternLayout.start();
-    }
-
-    public GelfMessage createMessage(GelfAppender appender, ILoggingEvent event) {
-        GelfMessage message = new GelfMessage()
-                .setTimestampMillis(event.getTimeStamp());
-
-        String originHost = appender.getOriginHost();
-        if (originHost != null) {
-            message.setHost(originHost);
-        }
-
-        if (appender.isLevelIncluded()) {
-            message.setLevel(LevelToSyslogSeverity.convert(event));
-        }
-
-        if (appender.isLocationIncluded()) {
-            StackTraceElement locationInformation = event.getCallerData()[0];
-            message.setFile(locationInformation.getFileName());
-            message.setLine(locationInformation.getLineNumber());
-        }
-
-        if (appender.isLoggerIncluded()) {
-            message.setLogger(event.getLoggerName());
-        }
-
-        if (appender.isMarkerIncluded()) {
-            Marker marker = event.getMarker();
-            if (marker != null) {
-                message.setMarker(marker.getName());
-            }
-        }
-
-        if (appender.isMdcIncluded()) {
-            Map<String, String> mdc = event.getMDCPropertyMap();
-            if (mdc != null) {
-                for (Map.Entry<String, String> entry : mdc.entrySet()) {
-                    message.addField(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-
-        if (appender.isThreadIncluded()) {
-            message.setThread(event.getThreadName());
-        }
-
-        message.setShortMessage(shortPatternLayout.doLayout(event));
-
-        String fullMessage = fullPatternLayout.doLayout(event);
-        if (!fullMessage.isEmpty()) {
-            message.setFullMessage(fullMessage);
-        }
-
-        message.setFacility(appender.getFacility());
-
-        Map<String, String> fields = appender.getAdditionalFields();
-        for (Map.Entry<String, String> entry : fields.entrySet()) {
-            message.addField(entry.getKey(), entry.getValue());
-        }
-
-        return message;
-    }
+    GelfMessage createMessage(GelfAppender appender, ILoggingEvent event);
 }

--- a/src/test/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactoryTest.java
+++ b/src/test/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactoryTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class GelfMessageFactoryTest {
+public class DefaultGelfMessageFactoryTest {
 
     private static final String HOST = "host";
     private static final String MDC_KEY = "mdcKey";
@@ -36,7 +36,7 @@ public class GelfMessageFactoryTest {
         when(event.getMDCPropertyMap())
                 .thenReturn(Collections.singletonMap(MDC_KEY, MDC_VALUE));
 
-        marshaller = new GelfMessageFactory();
+        marshaller = new DefaultGelfMessageFactory();
     }
 
     @Test


### PR DESCRIPTION
Users can use this to change the DefaultGelfMessageFactory behaviour

Example:
    <appender name="graylogMessages" class="com.github.pukkaone.gelf.logback.GelfAppender">
        ...
        <marshaller class="my.custom.package..MyGelfMessageFactory">
            <mdcTimestampProperty>ReceivedDateTime</mdcTimestampProperty>
        </marshaller>
        ...
    </appender>
