### PR TITLE
Configurable patterns in DefaultGelfMessageFactory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -128,3 +128,28 @@ Configure the custom GELF message factory in the appender:
   ...
 </appender>
 --
+
+If you just want to customize the `short_message` and `full_message` fields of
+the GELF messages sent by the appender, you can customize the
+`DefaultGelfMessageFactory` to apply different patterns.
+
+Configure the default GELF message factory in the appender:
+[source,xml]
+--
+<appender name="GRAYLOG2" class="com.github.pukkaone.gelf.logback.GelfAppender">
+  ...
+  <marshaller class="com.github.pukkaone.gelf.logback.DefaultGelfMessageFactory">
+    <shortMessagePattern>%.-20m</shortMessagePattern> <!-- at most 20 initial characters -->
+    <fullMessagePattern>%m%n%xEx</fullMessagePattern> <!-- the log message, a newline and the exception -->
+  </marshaller>
+  ...
+</appender>
+--
+
+The default patterns are:
+
+`shortMessagePattern`::
+    *%m%nopex* - full log message, ignores exceptions
+
+`fullMessagePattern`::
+    *%xEx* - full exception information

--- a/src/main/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactory.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/DefaultGelfMessageFactory.java
@@ -13,6 +13,9 @@ import java.util.Map;
  */
 public class DefaultGelfMessageFactory implements GelfMessageFactory {
 
+    private static final String DEFAULT_SHORT_MESSAGE_PATTERN = "%m%nopex";
+    private static final String DEFAULT_FULL_MESSAGE_PATTERN = "%xEx";
+
     private PatternLayout shortPatternLayout;
     private PatternLayout fullPatternLayout;
 
@@ -20,13 +23,13 @@ public class DefaultGelfMessageFactory implements GelfMessageFactory {
         // Short message contains event message and no stack trace.
         shortPatternLayout = new PatternLayout();
         shortPatternLayout.setContext(new LoggerContext());
-        shortPatternLayout.setPattern("%m%nopex");
+        shortPatternLayout.setPattern(DEFAULT_SHORT_MESSAGE_PATTERN);
         shortPatternLayout.start();
 
         // Full message contains stack trace.
         fullPatternLayout = new PatternLayout();
         fullPatternLayout.setContext(new LoggerContext());
-        fullPatternLayout.setPattern("%xEx");
+        fullPatternLayout.setPattern(DEFAULT_FULL_MESSAGE_PATTERN);
         fullPatternLayout.start();
     }
 
@@ -93,5 +96,19 @@ public class DefaultGelfMessageFactory implements GelfMessageFactory {
 
     protected void addMessageField(Map<String, String> map, GelfMessage message, String key, Object value) {
         message.addField(key, value);
+    }
+
+    public void setShortMessagePattern(String shortMessagePattern) {
+        setMessagePattern(shortPatternLayout, shortMessagePattern);
+    }
+
+    public void setFullMessagePattern(String fullMessagePattern) {
+        setMessagePattern(fullPatternLayout, fullMessagePattern);
+    }
+
+    private void setMessagePattern(PatternLayout patternLayout, String messagePattern) {
+        patternLayout.stop();
+        patternLayout.setPattern(messagePattern);
+        patternLayout.start();
     }
 }


### PR DESCRIPTION
Sometimes it is desirable to use the default marshaller, but just
change the message patterns. For example, one might want to include the
log event message in full message, and trim the short message to 50
characters at the most. Prior to this change it required implementing a
custom marshaller or using reflection to lookup the pattern layouts and
reconfigure them.

With this change, setting custom patterns is a first-class citizen.
