### PR TITLE
Allow AMQP automatic recovery to be enabled

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,6 +45,7 @@ To send by AMQP:
   <amqpExchange>messages</amqpExchange>
   <amqpRoutingKey>gelfudp</amqpRoutingKey>
   <amqpMaxRetries>5</amqpMaxRetries>
+  <amqpAutomaticRecovery>true</amqpAutomaticRecovery>
   <originHost>my.machine.example.com</originHost>
   <facility>gelf-java</facility>
   <additionalField>application=MyApplication</additionalField>
@@ -104,6 +105,9 @@ To send by AMQP:
 
 `amqpMaxRetries`::
     Maximum retries count; default value 0 (*optional*)
+
+`amqpAutomaticRecovery`::
+    Sets automatic recovery flag for underlying AMQP connection factory; default false (*optional*)
 
 `sslTrustAllCertificates`::
     Skip SSL server certificate validation; default false (*optional*)

--- a/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
+++ b/src/main/java/com/github/pukkaone/gelf/logback/GelfAppender.java
@@ -38,6 +38,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private String amqpExchange;
     private String amqpRoutingKey;
     private int amqpMaxRetries;
+    private boolean amqpAutomaticRecovery = false;
     private boolean sslTrustAllCertificates;
     private GelfMessageFactory marshaller = new DefaultGelfMessageFactory();
     private GelfSender gelfSender;
@@ -183,6 +184,14 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         this.amqpMaxRetries = amqpMaxRetries;
     }
 
+    public boolean isAmqpAutomaticRecovery() {
+        return amqpAutomaticRecovery;
+    }
+
+    public void setAmqpAutomaticRecovery(boolean amqpAutomaticRecovery) {
+        this.amqpAutomaticRecovery = amqpAutomaticRecovery;
+    }
+
     public boolean isSslTrustAllCertificates() {
         return sslTrustAllCertificates;
     }
@@ -222,10 +231,11 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
             String amqpURI,
             String amqpExchange,
             String amqpRoutingKey,
-            int amqpMaxRetries)
+            int amqpMaxRetries,
+            boolean amqpAutomaticRecovery)
         throws IOException, URISyntaxException, NoSuchAlgorithmException, KeyManagementException
     {
-        return new GelfAMQPSender(amqpURI, amqpExchange, amqpRoutingKey, amqpMaxRetries);
+        return new GelfAMQPSender(amqpURI, amqpExchange, amqpRoutingKey, amqpMaxRetries, amqpAutomaticRecovery);
     }
 
     @Override
@@ -250,7 +260,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
                 String udpGraylogHost = graylogHost.substring(4);
                 gelfSender = getGelfUDPSender(udpGraylogHost, graylogPort);
             } else if (amqpURI != null) {
-                gelfSender = getGelfAMQPSender(amqpURI, amqpExchange, amqpRoutingKey, amqpMaxRetries);
+                gelfSender = getGelfAMQPSender(amqpURI, amqpExchange, amqpRoutingKey, amqpMaxRetries, amqpAutomaticRecovery);
             } else {
                 gelfSender = getGelfUDPSender(graylogHost, graylogPort);
             }

--- a/src/main/java/com/github/pukkaone/gelf/protocol/GelfAMQPSender.java
+++ b/src/main/java/com/github/pukkaone/gelf/protocol/GelfAMQPSender.java
@@ -26,11 +26,12 @@ public class GelfAMQPSender extends GelfSender {
     private int maxRetries;
 
     public GelfAMQPSender(
-            String host, String exchangeName, String routingKey, int maxRetries)
+            String host, String exchangeName, String routingKey, int maxRetries, boolean automaticRecovery)
         throws IOException, URISyntaxException, NoSuchAlgorithmException, KeyManagementException
     {
         factory = new ConnectionFactory();
         factory.setUri(host);
+        factory.setAutomaticRecoveryEnabled(automaticRecovery);
 
         this.exchangeName = exchangeName;
         this.routingKey = routingKey;


### PR DESCRIPTION
Automatic recovery is disabled by default in AMQP and there was no way to change that flag.
The change keeps default to `false`, but allows the recovery to be enabled.